### PR TITLE
Update android async http

### DIFF
--- a/fh-android-sdk-test/pom.xml
+++ b/fh-android-sdk-test/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
     <properties>
-        <mockwebserver.version>2.0.0</mockwebserver.version>
+        <mockwebserver.version>2.4.0</mockwebserver.version>
     </properties>
 
     <dependencies>

--- a/fh-android-sdk-test/src/main/java/com/feedhenry/sdk/tests/api/FHSDKTest.java
+++ b/fh-android-sdk-test/src/main/java/com/feedhenry/sdk/tests/api/FHSDKTest.java
@@ -94,7 +94,7 @@ public class FHSDKTest extends AndroidTestCase {
         assertEquals("POST", request.getMethod().toUpperCase());
         assertEquals("/cloud/test", request.getPath());
 
-        String requestBody = new String(request.getBody(), "UTF-8");
+        String requestBody = new String(request.getBody().readUtf8());
         JSONObject requestJson = new JSONObject(requestBody);
         assertTrue(requestJson.has("__fh"));
 
@@ -235,7 +235,7 @@ public class FHSDKTest extends AndroidTestCase {
         }
 
         if (null != params) {
-            String requestBody = new String(request.getBody(), "UTF-8");
+            String requestBody = new String(request.getBody().readUtf8());
             assertEquals(requestBody.toString(), params.toString());
         }
 

--- a/fh-android-sdk/pom.xml
+++ b/fh-android-sdk/pom.xml
@@ -23,7 +23,7 @@
     </scm>
 
     <properties>
-        <loopj.version>1.4.6</loopj.version>
+        <loopj.version>1.4.8</loopj.version>
         <aerogear.android.push.version>2.2.0</aerogear.android.push.version>
     </properties>
 

--- a/fh-android-sdk/src/main/java/com/feedhenry/sdk/FH.java
+++ b/fh-android-sdk/src/main/java/com/feedhenry/sdk/FH.java
@@ -353,8 +353,8 @@ public class FH {
      * @throws Exception if the app property file is not loaded
      */
     public static Header[] getDefaultParamsAsHeaders(Header[] pHeaders) throws Exception {
-        ArrayList<Header> headers = new ArrayList<Header>();
         JSONObject defaultParams = FH.getDefaultParams();
+        ArrayList<Header> headers = new ArrayList<Header>(defaultParams.length());
 
         for (Iterator<String> it = defaultParams.keys(); it.hasNext(); ) {
             String key = it.next();


### PR DESCRIPTION
The old Android Async HTTP library was causing a major bug where params were not being sent with the correct content type, causing the backend to ignore them.
Bumping the version to the latest (1.4.6 -> 1.4.8) fixes this issue.

The offending line was [this](https://github.com/loopj/android-async-http/blob/57c66245728c648c8b9b8e5ee9d46c808502ce86/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java#L1169):
`if (uriRequest instanceof HttpEntityEnclosingRequestBase && ((HttpEntityEnclosingRequestBase) uriRequest).getEntity() != null) {`
which has since been changed to [this](https://github.com/loopj/android-async-http/blob/cf70d2e43a46e8cfd0154ddef41b2526f3eadaaa/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java#L1374):
`if (uriRequest instanceof HttpEntityEnclosingRequestBase && ((HttpEntityEnclosingRequestBase) uriRequest).getEntity() != null && uriRequest.containsHeader(HEADER_CONTENT_TYPE)) {`

While I was there, I also made a small optimisation to a List allocation.