### PR TITLE
Fh 2090 sync improvments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ FHStarterProject/bin/*
 FHStarterProject/gen/*
 *android-support-*.jar
 FHStarterProject/.settings/
+fh-android-sdk-test/gen-external-apklibs/*
 
 ## Maven
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
   - cd fh-android-sdk-test
   - mvn clean package -DskipTests=true;
   - emulator -avd test -no-skin -no-audio -no-window&
-  - wget https://raw.githubusercontent.com/travis-ci/travis-cookbooks/master/ci_environment/android-sdk/files/default/android-wait-for-emulator
+  - wget https://raw.githubusercontent.com/travis-ci/travis-cookbooks/master/community-cookbooks/android-sdk/files/default/android-wait-for-emulator
   - chmod a+x ./android-wait-for-emulator
   - "./android-wait-for-emulator"
   - adb shell input keyevent 82

--- a/fh-android-sdk/src/main/java/com/feedhenry/sdk/sync/FHSyncClient.java
+++ b/fh-android-sdk/src/main/java/com/feedhenry/sdk/sync/FHSyncClient.java
@@ -122,7 +122,21 @@ public class FHSyncClient {
      * @param pQueryParams Query parameters for the dataset
      * @throws Exception thrown if FHSyncClient isn't initialised.
      */
-    public void manage(String pDataId, FHSyncConfig pConfig, JSONObject pQueryParams)
+    public void manage(String pDataId, FHSyncConfig pConfig, JSONObject pQueryParams) throws Exception {
+        manage(pDataId, pConfig, pQueryParams, new JSONObject());
+    }
+
+    /**
+     * Uses the sync client to manage a dataset.
+     *
+     * @param pDataId The id of the dataset.
+     * @param pConfig The sync configuration for the dataset. If not specified, the sync configuration
+     * passed in the initDev method will be used
+     * @param pQueryParams Query parameters for the dataset
+     * @param pMetaData Meta for the dataset
+     * @throws Exception thrown if FHSyncClient isn't initialised.
+     */
+    public void manage(String pDataId, FHSyncConfig pConfig, JSONObject pQueryParams, JSONObject pMetaData)
         throws Exception {
         if (!mInitialised) {
             throw new Exception("FHSyncClient isn't initialised. Have you called the initDev function?");
@@ -137,7 +151,7 @@ public class FHSyncClient {
             dataset.setNotificationHandler(mNotificationHandler);
         } else {
             dataset =
-                new FHSyncDataset(mContext, mNotificationHandler, pDataId, syncConfig, pQueryParams);
+                new FHSyncDataset(mContext, mNotificationHandler, pDataId, syncConfig, pQueryParams, pMetaData);
             mDataSets.put(pDataId, dataset);
             dataset.setSyncRunning(false);
             dataset.setInitialised(true);

--- a/fh-android-sdk/src/main/java/com/feedhenry/sdk/sync/FHSyncConfig.java
+++ b/fh-android-sdk/src/main/java/com/feedhenry/sdk/sync/FHSyncConfig.java
@@ -299,8 +299,16 @@ public class FHSyncConfig {
         this.mResendCrashedUpdates = mResendCrashedUpdates;
     }
 
+    /**
+     * Set if legacy mode is used
+     * @param mUseCustomSync
+     */
     public void setUseCustomSync(boolean mUseCustomSync) { this.mUseCustomSync = mUseCustomSync; }
 
+    /**
+     * Check if legacy mode is enabled
+     * @return
+     */
     public boolean useCustomSync() { return this.mUseCustomSync; };
 
     /**

--- a/fh-android-sdk/src/main/java/com/feedhenry/sdk/sync/FHSyncConfig.java
+++ b/fh-android-sdk/src/main/java/com/feedhenry/sdk/sync/FHSyncConfig.java
@@ -27,6 +27,7 @@ public class FHSyncConfig {
     private boolean mNotifyClientStorageFailed = false;
     private int mCrashCountWait = 10;
     private boolean mResendCrashedUpdates = true;
+    private boolean mUseCustomSync = false;
 
     private static final String KEY_SYNC_FREQUENCY = "syncFrequency";
     private static final String KEY_AUTO_SYNC_UPDATES = "autoSyncLocalUpdates";
@@ -297,6 +298,10 @@ public class FHSyncConfig {
     public void setResendCrashedUpdates(boolean mResendCrashedUpdates) {
         this.mResendCrashedUpdates = mResendCrashedUpdates;
     }
+
+    public void setUseCustomSync(boolean mUseCustomSync) { this.mUseCustomSync = mUseCustomSync; }
+
+    public boolean useCustomSync() { return this.mUseCustomSync; };
 
     /**
      * Gets a JSON representation of the configuration object.

--- a/fh-android-sdk/src/main/java/com/feedhenry/sdk/sync/FHSyncDataset.java
+++ b/fh-android-sdk/src/main/java/com/feedhenry/sdk/sync/FHSyncDataset.java
@@ -63,12 +63,13 @@ public class FHSyncDataset {
 
     public FHSyncDataset(
         Context pContext, FHSyncNotificationHandler pHandler, String pDatasetId,
-        FHSyncConfig pConfig, JSONObject pQueryParams) {
+        FHSyncConfig pConfig, JSONObject pQueryParams, JSONObject pMetaData) {
         mContext = pContext;
         mNotificationHandler = pHandler;
         mDatasetId = pDatasetId;
         mSyncConfig = pConfig;
         mQueryParams = pQueryParams;
+        mMetaData = pMetaData;
         readFromFile();
     }
 
@@ -171,6 +172,7 @@ public class FHSyncDataset {
             JSONObject syncLoopParams = new JSONObject();
             syncLoopParams.put("fn", "sync");
             syncLoopParams.put("dataset_id", mDatasetId);
+            syncLoopParams.put("meta_data", mMetaData);
             syncLoopParams.put("query_params", mQueryParams);
             if (mHashvalue != null) {
                 syncLoopParams.put("dataset_hash", mHashvalue);
@@ -250,7 +252,9 @@ public class FHSyncDataset {
             processUpdates(updates.optJSONObject("failed"), NotificationMessage.REMOTE_UPDATE_FAILED_CODE, ack);
             processUpdates(updates.optJSONObject("collisions"), NotificationMessage.COLLISION_DETECTED_CODE, ack);
             mAcknowledgements = ack;
-        } else if (pData.has("hash") && !pData.getString("hash").equals(mHashvalue)) {
+        }
+
+        if (pData.has("hash") && !pData.getString("hash").equals(mHashvalue)) {
             String remoteHash = pData.getString("hash");
             FHLog.d(
                 LOG_TAG,
@@ -274,6 +278,7 @@ public class FHSyncDataset {
         syncRecsParams.put("fn", "syncRecords");
         syncRecsParams.put("dataset_id", mDatasetId);
         syncRecsParams.put("query_params", mQueryParams);
+        syncRecsParams.put("meta_data", mMetaData);
         syncRecsParams.put("clientRecs", clientRecords);
 
         FHLog.d(LOG_TAG, "syncRecParams :: " + syncRecsParams);


### PR DESCRIPTION
* Add support for the new sync endpoints
* Allow set metadata when syncClient.manage is called
* Use the hash value of the pending record as the temp uid so that it can be linked to the new uid later on