### PR TITLE
OSS parent and some more needed metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>9</version>
+    </parent>
+
     <groupId>com.feedhenry</groupId>
     <artifactId>fh-android-sdk-parent</artifactId>
     <version>3.1.0-SNAPSHOT</version>
@@ -20,6 +26,19 @@
         <url>git@github.com:feedhenry/fh-android-sdk.git</url>
         <tag>HEAD</tag>
     </scm>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <organization>
+      <name>Red Hat</name>
+      <url>http://www.feedhenry.org</url>
+    </organization>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
using a OSS parent (requirement for Maven Central), however, if we publish to JBoss Nexus, it's debatable if we use jboss-parent pom.

Also, stating LICENSE in the root pom, as well adding an organization tag (Not sure if the legal entity is really "FeedHenry by Red Hat" is.

@johnfriz might know this