### PR TITLE
Remvoing private m2 repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,14 +151,4 @@
             </modules>
         </profile>
     </profiles>
-    <distributionManagement>
-        <repository>
-            <id>releases-repo</id>
-            <url>https://github.com/feedhenry/fh-android-sdk-repository/raw/master/releases</url>
-        </repository>
-        <snapshotRepository>
-            <id>snapshot-repo</id>
-            <url>https://github.com/feedhenry/fh-android-sdk-repository/raw/master/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
 </project>


### PR DESCRIPTION
Before releasing to maven central, we have to get rid of private repos