### PR TITLE
Undo AGDroid 3.0.x upgrade

### DIFF
--- a/fh-android-sdk/pom.xml
+++ b/fh-android-sdk/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <loopj.version>1.4.9</loopj.version>
-    <aerogear.android.push.version>3.0.1</aerogear.android.push.version>
+    <aerogear.android.push.version>2.2.1</aerogear.android.push.version>
     <httpcomponents.version>4.3.5.1</httpcomponents.version>
   </properties>
 

--- a/fh-android-sdk/src/main/java/com/feedhenry/sdk/FH.java
+++ b/fh-android-sdk/src/main/java/com/feedhenry/sdk/FH.java
@@ -466,7 +466,7 @@ public class FH {
     public static void pushRegister(final PushConfig pPushConfig, final FHActCallback pCallback) {
         RegistrarManager.config(FH_PUSH_NAME, AeroGearGCMPushConfiguration.class)
             .setPushServerURI(URI.create(AppProps.getInstance().getPushServerUrl()))
-            .setSenderId(AppProps.getInstance().getPushSenderId())
+            .setSenderIds(AppProps.getInstance().getPushSenderId())
             .setVariantID(AppProps.getInstance().getPushVariant())
             .setSecret(AppProps.getInstance().getPushSecret())
             .setAlias(pPushConfig.getAlias())


### PR DESCRIPTION
Since we and to release 3.1.0 (or should we actually name the JAR 3.0.1??) to Maven central,

I feel it's better to not include the 3.0.x of AGDroid, since that contains GCM-3 fixes... 