### PR TITLE
Check if connection tags is disabled

### DIFF
--- a/library/src/main/java/com/feedhenry/sdk/FH.java
+++ b/library/src/main/java/com/feedhenry/sdk/FH.java
@@ -117,7 +117,8 @@ public class FH {
      * @param pCallback the callback function to be executed after initialization is finished
      */
     public static void init(Context pContext, final FHActCallback pCallback) {
-        mContext = pContext;
+        // Be sure we are store the safety application context
+        mContext = pContext.getApplicationContext();
 
         // -- Load properties
         if (!mInitCalled) {


### PR DESCRIPTION
# How to test it

## Using this changes

I have shipped a pre-release version on Sonatype. You can use that in your test.

Add the following line in the root `build.gradle` :

```groovy
allprojects {
    repositories {
        jcenter()
        maven { url "https://oss.sonatype.org/content/repositories/comfeedhenry-1029/" }
    }
}
```

## Step by step to reproduce

- Create a new project Hello World;
- Bump the fh-android-sdk dependency version in app/build.gradle to _3.3.2_
- Build a client Android application;
- Install and open this app in a device
- Go to Connection Tag Tab into The Build Client Tab
- Disable the connection tag
- Close the client app and open again. It should display the tag is disable

PS: It isn't going to kill. The app is displayed loading forever. There is an issue ([FH-3738](https://issues.jboss.org/browse/FH-3738)) to fix it in the in the [helloworld-android-gradle](https://github.com/feedhenry-templates/helloworld-android-gradle)
