### PR TITLE
Move coverage from coverage to codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FeedHenry Android SDK
 
 [![circle-ci](https://img.shields.io/circleci/project/github/feedhenry/fh-android-sdk/master.svg)](https://circleci.com/gh/feedhenry/fh-android-sdk)
-[![Coveralls](https://img.shields.io/coveralls/feedhenry/fh-android-sdk/master.svg)](https://coveralls.io/github/feedhenry/fh-android-sdk)
+[![Codecov](https://img.shields.io/codecov/c/github/codecov/fh-android-sdk/master.svg)](https://codecov.io/gh/feedhenry/fh-android-sdk)
 [![License](https://img.shields.io/badge/-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://img.shields.io/maven-central/v/com.feedhenry/fh-android-sdk.svg)](http://search.maven.org/#search%7Cga%7C1%7Cfh-android-sdk)
 [![Javadocs](http://www.javadoc.io/badge/com.feedhenry/fh-android-sdk.svg?color=blue)](http://www.javadoc.io/doc/com.feedhenry/fh-android-sdk)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FeedHenry Android SDK
 
 [![circle-ci](https://img.shields.io/circleci/project/github/feedhenry/fh-android-sdk/master.svg)](https://circleci.com/gh/feedhenry/fh-android-sdk)
-[![Codecov](https://img.shields.io/codecov/c/github/codecov/fh-android-sdk/master.svg)](https://codecov.io/gh/feedhenry/fh-android-sdk)
+[![codecov](https://codecov.io/gh/feedhenry/fh-android-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/feedhenry/fh-android-sdk)
 [![License](https://img.shields.io/badge/-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://img.shields.io/maven-central/v/com.feedhenry/fh-android-sdk.svg)](http://search.maven.org/#search%7Cga%7C1%7Cfh-android-sdk)
 [![Javadocs](http://www.javadoc.io/badge/com.feedhenry/fh-android-sdk.svg?color=blue)](http://www.javadoc.io/doc/com.feedhenry/fh-android-sdk)

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0-rc2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
     }
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -32,3 +32,6 @@ test:
 
   override:
     - ./gradlew build connectedCheck
+
+  post:
+    - bash <(curl -s https://codecov.io/bash)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project: 
+      default:
+        target: auto  # this is default
+        if_not_found: success  # no commit found? still set a success

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,8 +1,5 @@
-plugins {
-    id "com.github.kt3k.coveralls" version "2.8.1"
-}
-
 apply plugin: "com.android.library"
+apply plugin: 'jacoco-android'
 
 android {
     compileSdkVersion 26
@@ -62,21 +59,6 @@ dependencies {
     androidTestImplementation "com.google.dexmaker:dexmaker:1.1"
     androidTestImplementation "com.google.dexmaker:dexmaker-mockito:1.1"
     androidTestImplementation "com.squareup.okhttp:mockwebserver:2.4.0"
-}
-
-coveralls {
-    sourceDirs = files("library/src/main/java").flatten()
-    jacocoReportPath = "${buildDir}/reports/coverage/debug/report.xml"
-}
-
-tasks.coveralls {
-    dependsOn "connectedAndroidTest"
-    onlyIf { System.env."CI" }
-}
-
-task copyLibs(type: Copy) {
-    from configurations.compile
-    into 'libs'
 }
 
 apply from: '../gradle-mvn-push.gradle'


### PR DESCRIPTION
Related issues:

* [FH-4313](https://issues.jboss.org/browse/FH-4313) - Move fh-android-sdk from Coveralls to Codecov